### PR TITLE
add browser sync to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bs-config.js",
   "dependencies": {},
   "devDependencies": {
+    "browser-sync": "^2.11.1",
     "gaze-cli": "^0.2.0",
     "less": "^2.5.3",
     "npm-run-all": "^1.5.0"


### PR DESCRIPTION
```
snip...

info]     └── isexe@1.1.1
[info]
[info] Done 'npm install'.
[success] Total time: 11 s, completed Feb 3, 2016 5:46:53 PM
[info] Running 'npm run build' ...
[info] Generating /Users/kga/git/github.com/motemen/prchecklist/target/scala-2.11/resource_managed/main/rebel.xml.
[info] Updating {file:/Users/kga/git/github.com/motemen/prchecklist/}prchecklist...

> github-release-pull-requests-checklist@1.0.0 watch /Users/kga/git/github.com/motemen/prchecklist
> npm-run-all -p watch:less browser-sync:start

[info]
[info] > github-release-pull-requests-checklist@1.0.0 build /Users/kga/git/github.com/motemen/prchecklist
[info] > lessc --verbose --source-map src/main/less/*.less src/main/webapp/stylesheets/main.css
[info]
[info] Resolving com.googlecode.juniversalchardet#juniversalchardet;1.0.3 ...

> github-release-pull-requests-checklist@1.0.0 watch:less /Users/kga/git/github.com/motemen/prchecklist
> gaze 'lessc --verbose --source-map src/main/less/*.less src/main/webapp/stylesheets/main.css' 'src/main/less/*.less'
[info] Resolving eu.medsea.mimeutil#mime-util;2.1.3 ...

> github-release-pull-requests-checklist@1.0.0 browser-sync:start /Users/kga/git/github.com/motemen/prchecklist
> browser-sync start --config bs-config.js

sh: browser-sync: command not found

npm ERR! Darwin 15.3.0
npm ERR! argv "/usr/local/Cellar/node/5.4.1/bin/node" "/usr/local/bin/npm" "run-script" "browser-sync:start"
npm ERR! node v5.4.1
npm ERR! npm  v3.3.12
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! github-release-pull-requests-checklist@1.0.0 browser-sync:start: `browser-sync start --config bs-config.js`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the github-release-pull-requests-checklist@1.0.0 browser-sync:start script 'browser-sync start --config bs-config.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the github-release-pull-requests-checklist package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     browser-sync start --config bs-config.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls github-release-pull-requests-checklist
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
[info] Resolving org.joda#joda-convert;1.8.1 ...
[info] lessc: wrote /Users/kga/git/github.com/motemen/prchecklist/src/main/webapp/stylesheets/main.css
[info] lessc: wrote /Users/kga/git/github.com/motemen/prchecklist/src/main/webapp/stylesheets/main.css.map
[info] Done 'npm run build'.
ERROR: browser-sync:start: None-Zero Exit(1);

snip...
```