### PR TITLE
Check stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ jrebel.lic
 /.lib/
 
 /node_modules/
+/npm-debug.log.*

--- a/db/prchecklist.sql
+++ b/db/prchecklist.sql
@@ -10,7 +10,8 @@ CREATE TABLE checklists (
     id                SERIAL NOT NULL PRIMARY KEY,
     github_repo_id    INTEGER NOT NULL REFERENCES github_repos (id),
     release_pr_number INTEGER NOT NULL,
-    UNIQUE            (github_repo_id, release_pr_number)
+    stage             VARCHAR(64) NOT NULL DEFAULT '',
+    UNIQUE            (github_repo_id, release_pr_number, stage)
 );
 
 CREATE TABLE checks (

--- a/src/main/less/main.less
+++ b/src/main/less/main.less
@@ -56,6 +56,10 @@ h1 {
   small {
     display: block;
   }
+  .stage {
+    color: grey;
+    text-transform: uppercase;
+  }
 }
 #checklist {
   list-style: none;

--- a/src/main/scala/prchecklist/AppServlet.scala
+++ b/src/main/scala/prchecklist/AppServlet.scala
@@ -99,7 +99,7 @@ class AppServletBase extends ScalatraServlet with FutureSupport with ScalateSupp
         val client = createGitHubHttpClient(getVisitor getOrElse repo.defaultUser)
         val githubService = createGitHubService(client)
         val prWithCommits = githubService.getPullRequestWithCommits(repo, params('pullRequestNumber).toInt).run
-        val (checklist, _) = Await.result(ChecklistService.getChecklist(repo, prWithCommits), Duration.Inf)
+        val (checklist, _) = Await.result(ChecklistService.getChecklist(repo, prWithCommits, "" /* TODO */ ), Duration.Inf)
         f(repo, checklist)
     }
   }

--- a/src/main/scala/prchecklist/models/Types.scala
+++ b/src/main/scala/prchecklist/models/Types.scala
@@ -1,6 +1,6 @@
 package prchecklist.models
 
-case class ReleaseChecklist(id: Int, repo: Repo, pullRequest: GitHubTypes.PullRequest, featurePullRequests: List[PullRequestReference], checks: Map[Int, Check]) {
+case class ReleaseChecklist(id: Int, repo: Repo, pullRequest: GitHubTypes.PullRequest, stage: String, featurePullRequests: List[PullRequestReference], checks: Map[Int, Check]) {
   def pullRequestUrl(number: Int) = repo.pullRequestUrl(number)
 
   def allGreen = checks.values.forall(_.isChecked)

--- a/src/main/scala/prchecklist/services/ChecklistService.scala
+++ b/src/main/scala/prchecklist/services/ChecklistService.scala
@@ -34,7 +34,7 @@ object ChecklistService extends SQLInterpolation with CompoundParameter {
         val q = for {
           (checklistId, created) <- ensureChecklist(repo, prWithCommits.pullRequest.number, stage)
           checks <- queryChecklistChecks(checklistId, prRefs)
-        } yield (ReleaseChecklist(checklistId, repo, prWithCommits.pullRequest, prRefs.toList, checks), created)
+        } yield (ReleaseChecklist(checklistId, repo, prWithCommits.pullRequest, stage, prRefs.toList, checks), created)
 
         db.run(q.transactionally)
     }

--- a/src/main/scala/prchecklist/services/ChecklistService.scala
+++ b/src/main/scala/prchecklist/services/ChecklistService.scala
@@ -23,7 +23,7 @@ object ChecklistService extends SQLInterpolation with CompoundParameter {
     }
   }
 
-  def getChecklist(repo: Repo, prWithCommits: GitHubTypes.PullRequestWithCommits): Future[(ReleaseChecklist, Boolean)] = {
+  def getChecklist(repo: Repo, prWithCommits: GitHubTypes.PullRequestWithCommits, stage: String): Future[(ReleaseChecklist, Boolean)] = {
     val db = Database.get
 
     mergedPullRequests(prWithCommits.commits) match {
@@ -32,7 +32,7 @@ object ChecklistService extends SQLInterpolation with CompoundParameter {
 
       case Some(prRefs) =>
         val q = for {
-          (checklistId, created) <- ensureChecklist(repo, prWithCommits.pullRequest.number)
+          (checklistId, created) <- ensureChecklist(repo, prWithCommits.pullRequest.number, stage)
           checks <- queryChecklistChecks(checklistId, prRefs)
         } yield (ReleaseChecklist(checklistId, repo, prWithCommits.pullRequest, prRefs.toList, checks), created)
 
@@ -79,21 +79,22 @@ object ChecklistService extends SQLInterpolation with CompoundParameter {
     db.run(q)
   }
 
-  private def ensureChecklist(repo: Repo, number: Int): DBIO[(Int, Boolean)] = {
+  private def ensureChecklist(repo: Repo, number: Int, stage: String): DBIO[(Int, Boolean)] = {
     sql"""
       | SELECT id
       | FROM checklists
       | WHERE github_repo_id = ${repo.id}
       |   AND release_pr_number = ${number}
+      |   AND stage = ${stage}
       | LIMIT 1
     """.as[Int].map(_.headOption).flatMap {
       case Some(v) => DBIO.successful((v, false))
       case None =>
         sql"""
           | INSERT INTO checklists
-          |   (github_repo_id, release_pr_number)
+          |   (github_repo_id, release_pr_number, stage)
           | VALUES
-          |   (${repo.id}, ${number})
+          |   (${repo.id}, ${number}, ${stage})
           | RETURNING id
         """.as[Int].head.map((_, true))
     }

--- a/src/main/scala/prchecklist/views/Helper.scala
+++ b/src/main/scala/prchecklist/views/Helper.scala
@@ -3,6 +3,8 @@ package prchecklist.views
 import org.pegdown.plugins.PegDownPlugins
 import org.pegdown.{ Extensions, Parser, PegDownProcessor }
 
+import prchecklist.models._
+
 object Helper {
   val githubFlavouredMarkdownExtensions = {
     import Extensions._
@@ -14,4 +16,12 @@ object Helper {
   def formatMarkdown(source: String): String = {
     pegdown.markdownToHtml(source)
   }
+
+  def checklistPath(checklist: ReleaseChecklist): String = {
+    s"/${checklist.repo.fullName}/pull/${checklist.pullRequest.number}" + (checklist.stage match {
+      case "" => ""
+      case stage => s"/$stage"
+    })
+  }
+
 }

--- a/src/main/webapp/WEB-INF/templates/views/pullRequest.jade
+++ b/src/main/webapp/WEB-INF/templates/views/pullRequest.jade
@@ -12,6 +12,10 @@
         a(href={checklist.pullRequestUrl(checklist.pullRequest.number)})
           | ##{checklist.pullRequest.number.toString}
         | #{checklist.pullRequest.title}
+        = if (checklist.stage.nonEmpty)
+          span.stage
+            | ::
+            = checklist.stage
 
     .description
       != formatMarkdown(checklist.pullRequest.body)

--- a/src/main/webapp/WEB-INF/templates/views/pullRequest.jade
+++ b/src/main/webapp/WEB-INF/templates/views/pullRequest.jade
@@ -35,12 +35,12 @@
               = visitor match
                 - case Some(visitor) =>
                   - if (check.isCheckedBy(visitor))
-                    form(method="POST" action="/#{checklist.repo.fullName}/pull/#{checklist.pullRequest.number.toString}/-/uncheck/#{check.pullRequest.number.toString}")
+                    form(method="POST" action="#{checklistPath(checklist)}/-/uncheck/#{check.pullRequest.number.toString}")
                       button.btn.btn-sm.btn-success(type="submit")
                         i.fa.fa-check
                         i.fa.fa-times
                   - else
-                    form(method="POST" action="/#{checklist.repo.fullName}/pull/#{checklist.pullRequest.number.toString}/-/check/#{check.pullRequest.number.toString}")
+                    form(method="POST" action="#{checklistPath(checklist)}/-/check/#{check.pullRequest.number.toString}")
                       button.btn.btn-sm.btn-default(type="submit")
                         i.fa.fa-check
                 - case None =>

--- a/src/test/scala/prchecklist/services/ChecklistServiceSpec.scala
+++ b/src/test/scala/prchecklist/services/ChecklistServiceSpec.scala
@@ -39,7 +39,7 @@ class ChecklistServiceSpec extends FunSuite with Matchers with OptionValues with
     )
 
     val fut = for {
-      (checklist, created) <- ChecklistService.getChecklist(repo, pr)
+      (checklist, created) <- ChecklistService.getChecklist(repo, pr, stage = "")
       _ <- Future.successful {
         checklist.checks.get(2).value shouldNot be('checked)
         checklist.checks.get(3).value shouldNot be('checked)
@@ -48,7 +48,7 @@ class ChecklistServiceSpec extends FunSuite with Matchers with OptionValues with
 
       _ <- ChecklistService.checkChecklist(checklist, checkerUser, featurePRNumber = 2)
 
-      (checklist, created) <- ChecklistService.getChecklist(repo, pr)
+      (checklist, created) <- ChecklistService.getChecklist(repo, pr, stage = "")
       _ <- Future.successful {
         checklist.checks.get(2).value shouldBe 'checked
         checklist.checks.get(3).value shouldNot be('checked)
@@ -58,7 +58,7 @@ class ChecklistServiceSpec extends FunSuite with Matchers with OptionValues with
 
       _ <- ChecklistService.checkChecklist(checklist, checkerUser, featurePRNumber = 3)
 
-      (checklist, created) <- ChecklistService.getChecklist(repo, pr)
+      (checklist, created) <- ChecklistService.getChecklist(repo, pr, stage = "")
       _ <- Future.successful {
         checklist.checks.get(2).value shouldBe 'checked
         checklist.checks.get(3).value shouldBe 'checked

--- a/src/test/scala/prchecklist/web/ServletSpec.scala
+++ b/src/test/scala/prchecklist/web/ServletSpec.scala
@@ -42,7 +42,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
         .thenReturn(Task {
           GitHubTypes.PullRequestWithCommits(
             pullRequest = GitHubTypes.PullRequest(
-              number = 1,
+              number = 2,
               title = "title",
               body = "body",
               state = "open",
@@ -52,7 +52,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
             ),
             commits = List(
               GitHubTypes.Commit("", GitHubTypes.CommitDetail(
-                """Merge pull request #2 from motemen/feature-a
+                """Merge pull request #1 from motemen/feature-a
                   |
                   |feature-a
                 """.stripMargin
@@ -114,7 +114,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
       stubJson(
         "/repos/motemen/test-repository/pulls/2",
         PullRequest(
-          number = 1,
+          number = 2,
           title = "title",
           body = "body",
           state = "open",


### PR DESCRIPTION
Use `/:owner/:repo/pull/:number/:stage` path to support multiple checklist stages e.g.:

- `/motemen/example/pull/123/qa` and
- `/motemen/example/pull/123/production`,

which are independent.