### PR TITLE
fix error when no merged pull request

### DIFF
--- a/src/main/scala/prchecklist/AppServlet.scala
+++ b/src/main/scala/prchecklist/AppServlet.scala
@@ -114,13 +114,18 @@ trait AppServletBase extends ScalatraServlet with FutureSupport with ScalateSupp
   }
 
   val viewPullRequest = get("/:repoOwner/:repoName/pull/:pullRequestNumber(/:stage)") {
-    requireChecklist {
-      (repo, checklist) =>
-        contentType = "text/html"
-        layoutTemplate(
-          "/WEB-INF/templates/views/pullRequest.jade",
-          "checklist" -> checklist
-        )
+    try {
+      requireChecklist {
+        (repo, checklist) =>
+          contentType = "textre/html"
+          layoutTemplate(
+            "/WEB-INF/templates/views/pullRequest.jade",
+            "checklist" -> checklist
+          )
+      }
+    } catch {
+      case e: Exception =>
+        NotFound("No merged pull requests")
     }
   }
 

--- a/src/test/scala/prchecklist/web/ServletSpec.scala
+++ b/src/test/scala/prchecklist/web/ServletSpec.scala
@@ -177,7 +177,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
   test("viewPullRequest") {
     session {
       get("/motemen/test-repository/pull/2") {
-        status should equal (404)
+        status should equal (200)
       }
 
       put("/@user?login=test-user") {
@@ -185,6 +185,10 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
       }
 
       get("/motemen/test-repository/pull/2") {
+        status should equal (200)
+      }
+
+      get("/motemen/test-repository/pull/9") {
         status should equal (404)
       }
     }

--- a/src/test/scala/prchecklist/web/ServletSpec.scala
+++ b/src/test/scala/prchecklist/web/ServletSpec.scala
@@ -177,7 +177,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
   test("viewPullRequest") {
     session {
       get("/motemen/test-repository/pull/2") {
-        status should equal (200)
+        status should equal (404)
       }
 
       put("/@user?login=test-user") {
@@ -185,7 +185,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
       }
 
       get("/motemen/test-repository/pull/2") {
-        status should equal (200)
+        status should equal (404)
       }
     }
   }


### PR DESCRIPTION
`/{author}/{repo}/pull/1` shows error if the pr has no merged pull request.

```
java.util.concurrent.ExecutionException: Boxed Error
	at scala.concurrent.impl.Promise$.resolver(Promise.scala:55)
	at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolveTry(Promise.scala:47)
	at scala.concurrent.impl.Promise$KeptPromise.<init>(Promise.scala:324)
	at scala.concurrent.Promise$.fromTry(Promise.scala:142)
	at scala.concurrent.Promise$.failed(Promise.scala:128)
	at scala.concurrent.Future$.failed(Future.scala:467)
	at prchecklist.services.ChecklistServiceComponent$ChecklistService.getChecklist(ChecklistService.scala:54)
	at prchecklist.AppServletBase$$anonfun$prchecklist$AppServletBase$$requireChecklist$1.apply(AppServlet.scala:111)
	at prchecklist.AppServletBase$$anonfun$prchecklist$AppServletBase$$requireChecklist$1.apply(AppServlet.scala:106)
	at prchecklist.AppServletBase$class.prchecklist$AppServletBase$$requireGitHubRepo(AppServlet.scala:96)
	at prchecklist.AppServletBase$class.prchecklist$AppServletBase$$requireChecklist(AppServlet.scala:105)
	at prchecklist.AppServletBase$$anonfun$6.apply(AppServlet.scala:117)
	at org.scalatra.ScalatraBase$class.org$scalatra$ScalatraBase$$liftAction(ScalatraBase.scala:285)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:279)
	at org.scalatra.ScalatraBase$$anonfun$invoke$1.apply(ScalatraBase.scala:279)
	at org.scalatra.ScalatraBase$class.withRouteMultiParams(ScalatraBase.scala:356)
	at prchecklist.AppServlet.withRouteMultiParams(AppServlet.scala:40)
	at org.scalatra.ScalatraBase$class.invoke(ScalatraBase.scala:278)
	at prchecklist.AppServlet.invoke(AppServlet.scala:40)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:253)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1$$anonfun$apply$8.apply(ScalatraBase.scala:251)
	at scala.Option.flatMap(Option.scala:171)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:251)
	at org.scalatra.ScalatraBase$$anonfun$runRoutes$1.apply(ScalatraBase.scala:250)
	at scala.collection.immutable.Stream.flatMap(Stream.scala:493)
	at org.scalatra.ScalatraBase$class.runRoutes(ScalatraBase.scala:250)
	at prchecklist.AppServlet.runRoutes(AppServlet.scala:40)
	at org.scalatra.ScalatraBase$class.runActions$1(ScalatraBase.scala:175)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply$mcV$sp(ScalatraBase.scala:187)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply(ScalatraBase.scala:187)
	at org.scalatra.ScalatraBase$$anonfun$executeRoutes$1.apply(ScalatraBase.scala:187)
	at org.scalatra.ScalatraBase$class.org$scalatra$ScalatraBase$$cradleHalt(ScalatraBase.scala:205)
	at org.scalatra.ScalatraBase$class.executeRoutes(ScalatraBase.scala:187)
	at prchecklist.AppServlet.executeRoutes(AppServlet.scala:40)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply$mcV$sp(ScalatraBase.scala:126)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply(ScalatraBase.scala:126)
	at org.scalatra.ScalatraBase$$anonfun$handle$1.apply(ScalatraBase.scala:126)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
	at org.scalatra.DynamicScope$class.withResponse(DynamicScope.scala:78)
	at prchecklist.AppServlet.withResponse(AppServlet.scala:40)
	at org.scalatra.DynamicScope$$anonfun$withRequestResponse$1.apply(DynamicScope.scala:58)
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58)
	at org.scalatra.DynamicScope$class.withRequest(DynamicScope.scala:69)
	at prchecklist.AppServlet.withRequest(AppServlet.scala:40)
	at org.scalatra.DynamicScope$class.withRequestResponse(DynamicScope.scala:57)
	at prchecklist.AppServlet.withRequestResponse(AppServlet.scala:40)
	at org.scalatra.ScalatraBase$class.handle(ScalatraBase.scala:125)
	at prchecklist.AppServlet.org$scalatra$servlet$ServletBase$$super$handle(AppServlet.scala:40)
	at org.scalatra.servlet.ServletBase$class.handle(ServletBase.scala:53)
	at prchecklist.AppServlet.org$scalatra$scalate$ScalateSupport$$super$handle(AppServlet.scala:40)
	at org.scalatra.scalate.ScalateSupport$class.handle(ScalateSupport.scala:152)
	at prchecklist.AppServlet.handle(AppServlet.scala:40)
	at org.scalatra.ScalatraServlet$class.service(ScalatraServlet.scala:60)
	at prchecklist.AppServlet.service(AppServlet.scala:40)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:808)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:587)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:497)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Error: No merged pull requests
	... 67 more
```