### PR TITLE
Support multiple assignees

### DIFF
--- a/core/src/main/scala/prchecklist/models/GitHubTypes.scala
+++ b/core/src/main/scala/prchecklist/models/GitHubTypes.scala
@@ -18,7 +18,7 @@ object GitHubTypes {
     def isOpen = state == "open"
     def isClosed = state == "closed"
 
-    def usersInCharge = if (assignees.length > 0) assignees else List(user)
+    def usersInCharge = if (assignees.nonEmpty) assignees else List(user)
   }
 
   case class PullRequestWithCommits(pullRequest: PullRequest, commits: List[Commit])

--- a/core/src/main/scala/prchecklist/models/GitHubTypes.scala
+++ b/core/src/main/scala/prchecklist/models/GitHubTypes.scala
@@ -12,13 +12,13 @@ object GitHubTypes {
       head: CommitRef,
       base: CommitRef,
       commits: Int,
-      assignee: Option[User],
+      assignees: List[User],
       user: User) {
 
     def isOpen = state == "open"
     def isClosed = state == "closed"
 
-    def userInCharge = assignee getOrElse user
+    def usersInCharge = if (assignees.length > 0) assignees else List(user)
   }
 
   case class PullRequestWithCommits(pullRequest: PullRequest, commits: List[Commit])

--- a/core/src/test/scala/prchecklist/services/ChecklistServiceSpec.scala
+++ b/core/src/test/scala/prchecklist/services/ChecklistServiceSpec.scala
@@ -70,7 +70,7 @@ class ChecklistServiceSpec extends FunSuite with Matchers with OptionValues with
               head = GitHubTypes.CommitRef(GitHubTypes.Repo("", false), "xxx", "xxx"),
               base = GitHubTypes.CommitRef(GitHubTypes.Repo("", false), "xxx", "xxx"),
               commits = 1,
-              assignee = None,
+              assignees = List(),
               user = GitHubTypes.User(login = "motemen", avatarUrl = "https://github.com/motemen.png")
             )
           }

--- a/core/src/test/scala/prchecklist/test/Factory.scala
+++ b/core/src/test/scala/prchecklist/test/Factory.scala
@@ -12,7 +12,7 @@ object Factory {
       head = createGitHubCommitRef.copy(ref = "feature-1"),
       base = createGitHubCommitRef.copy(ref = "master"),
       commits = 1,
-      assignee = None,
+      assignees = List(),
       user = GitHubTypes.User(login = "motemen", avatarUrl = "https://github.com/motemen.png")
     )
 

--- a/src/main/scala/prchecklist/views/package.scala
+++ b/src/main/scala/prchecklist/views/package.scala
@@ -7,7 +7,7 @@ package object views {
 
   case class PullRequest(url: String, number: Int, title: String, body: String)
 
-  case class Check(url: String, number: Int, title: String, users: List[User], checked: Boolean, assignee: User)
+  case class Check(url: String, number: Int, title: String, users: List[User], checked: Boolean, assignees: List[User])
 
   case class User(name: String, avatarUrl: String)
 
@@ -51,7 +51,7 @@ package object views {
               title = check.pullRequest.title,
               users = check.checkedUsers.map(u => User(name = u.login, avatarUrl = u.avatarUrl)),
               checked = visitor.exists(check.isCheckedBy(_)),
-              assignee = User(name = check.pullRequest.userInCharge.login, avatarUrl = check.pullRequest.userInCharge.avatarUrl)
+              assignees = check.pullRequest.usersInCharge.map(u => User(name = u.login, avatarUrl = u.avatarUrl))
             )
         }.toList,
         allChecked = checklist.allChecked

--- a/src/main/typescript/ChecklistComponent.tsx
+++ b/src/main/typescript/ChecklistComponent.tsx
@@ -194,7 +194,7 @@ export const ChecklistComponent = React.createClass<ChecklistComponentProps, Che
           <List>
           {
             state.checklist.checks.map((check: Check) => (
-              <ListItem secondaryText={<div style={{paddingLeft: 48}}>@{check.assignee.name}</div>}>
+              <ListItem secondaryText={<div style={{paddingLeft: 48}}>{check.assignees.map(assignee => <span style={{paddingLeft: 6}}>@{assignee.name}</span>)}</div>}>
                 <Checkbox
                   style={{position: 'absolute', left: 20, top: 24, width: 24}}
                   defaultChecked={check.checked}

--- a/src/main/typescript/api.ts
+++ b/src/main/typescript/api.ts
@@ -36,7 +36,7 @@ export interface Check {
   title:    string;
   users:    User[];
   checked:  boolean;
-  assignee: User;
+  assignees: User[];
 }
 
 export interface User {

--- a/src/test/scala/prchecklist/web/ServletSpec.scala
+++ b/src/test/scala/prchecklist/web/ServletSpec.scala
@@ -54,7 +54,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
               head = GitHubTypes.CommitRef(GitHubTypes.Repo("a/b", false), "", "feature-1"),
               base = GitHubTypes.CommitRef(GitHubTypes.Repo("a/b", false), "", "master"),
               commits = 1,
-              assignee = None,
+              assignees = List(),
               user = GitHubTypes.User(login = "motemen", avatarUrl = "https://github.com/motemen.png")
             ),
             commits = List(
@@ -120,7 +120,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
                 head = GitHubTypes.CommitRef(GitHubTypes.Repo("", false), "xxx", "xxx"),
                 base = GitHubTypes.CommitRef(GitHubTypes.Repo("", false), "xxx", "xxx"),
                 commits = 1,
-                assignee = None,
+                assignees = List(),
                 user = GitHubTypes.User(login = "motemen", avatarUrl = "https://github.com/motemen.png")
               )
             }
@@ -165,7 +165,7 @@ class ServletSpec extends ScalatraFunSuite with Matchers with OptionValues with 
             ref = "master"
           ),
           commits = 1,
-          assignee = None,
+          assignees = List(),
           user = GitHubTypes.User(login = "motemen", avatarUrl = "https://github.com/motemen.png")
         )
       )


### PR DESCRIPTION
closes #40 

## Server Side

- Changed to use `pull_request.assignees` instead of `pull_request.assignee`.

## Client Side

- Changed to display all assignees.